### PR TITLE
refactor(tic-tac-toe): use emojis when showing which player won

### DIFF
--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -51,7 +51,7 @@ function endGame(draw) {
   if (draw) {
     winningMessageTextElement.innerText = 'Draw!'
   } else {
-    winningMessageTextElement.innerText = `${circleTurn ? "O" : "X"} Wins!`
+    winningMessageTextElement.innerText = `${circleTurn ? "⚪️" : "❌"} Wins!`
   }
   winningMessageElement.classList.add('show')
 }


### PR DESCRIPTION
Changes `O` and `X` to `⚪️` and `❌` when showing who won. 

Problem is the readability with `O` as it might look like a zero
<img width="473" alt="image" src="https://github.com/Ellodev/finity/assets/50016870/97019430-632d-4500-a865-664715cf0b7c">
<img width="454" alt="image" src="https://github.com/Ellodev/finity/assets/50016870/8989b268-6b23-4103-860c-61062c5c3f55">
